### PR TITLE
Make UsbIss remember previous IO state

### DIFF
--- a/src/usb_iss/defs.py
+++ b/src/usb_iss/defs.py
@@ -46,7 +46,7 @@ class IOType(Enum):
     OUTPUT_HIGH = 0x01
     DIGITAL_INPUT = 0x02
     ANALOGUE_INPUT = 0x03
-    NULL = 0x00
+    NULL = 0xFF
 
 
 class SPIMode(Enum):

--- a/src/usb_iss/defs.py
+++ b/src/usb_iss/defs.py
@@ -46,7 +46,6 @@ class IOType(Enum):
     OUTPUT_HIGH = 0x01
     DIGITAL_INPUT = 0x02
     ANALOGUE_INPUT = 0x03
-    NULL = 0xFF
 
 
 class SPIMode(Enum):

--- a/src/usb_iss/usb_iss.py
+++ b/src/usb_iss/usb_iss.py
@@ -70,8 +70,8 @@ class UsbIss(object):
         self._drv.close()
 
     def setup_i2c(self, clock_khz=400, use_i2c_hardware=True,
-                  io1_type=defs.IOType.NULL,
-                  io2_type=defs.IOType.NULL):
+                  io1_type=None,
+                  io2_type=None):
         """
         Issue an ISS_MODE command to set the operating mode to I2C + IO.
 
@@ -85,9 +85,8 @@ class UsbIss(object):
             io2_type (defs.IOType): IO2 mode
         """
         i2c_mode = self._get_i2c_mode(clock_khz, use_i2c_hardware)
-        io_type = self._get_io_type(io1_type, io2_type,
-                                    defs.IOType.NULL, defs.IOType.NULL)
-        self._set_mode(i2c_mode, [io_type])
+        io_type = self._get_io_type(io1_type, io2_type, None, None)
+        self._set_mode(i2c_mode, [io_type & 0x0F])
         self.current_io_type = io_type
 
     def setup_i2c_serial(self, clock_khz=400, use_i2c_hardware=True,
@@ -120,10 +119,10 @@ class UsbIss(object):
         self._set_mode(spi_mode.value, [divisor])
 
     def setup_io(self,
-                 io1_type=defs.IOType.NULL,
-                 io2_type=defs.IOType.NULL,
-                 io3_type=defs.IOType.NULL,
-                 io4_type=defs.IOType.NULL):
+                 io1_type=None,
+                 io2_type=None,
+                 io3_type=None,
+                 io4_type=None):
         """
         Issue an ISS_MODE command to set the operating mode to IO.
 
@@ -138,10 +137,10 @@ class UsbIss(object):
         self.current_io_type = io_type
 
     def change_io(self,
-                  io1_type=defs.IOType.NULL,
-                  io2_type=defs.IOType.NULL,
-                  io3_type=defs.IOType.NULL,
-                  io4_type=defs.IOType.NULL):
+                  io1_type=None,
+                  io2_type=None,
+                  io3_type=None,
+                  io4_type=None):
         """
         Issue an ISS_MODE command to change the current IO mode without
         affecting serial or I2C settings.
@@ -157,8 +156,8 @@ class UsbIss(object):
         self.current_io_type = io_type
 
     def setup_serial(self, baud_rate=9600,
-                     io3_type=defs.IOType.NULL,
-                     io4_type=defs.IOType.NULL):
+                     io3_type=None,
+                     io4_type=None):
         """
         Issue an ISS_MODE command to set the operating mode to Serial + IO.
 
@@ -168,9 +167,8 @@ class UsbIss(object):
             io4_type (defs.IOType): IO4 mode
         """
         divisor = self._get_serial_divisor(baud_rate)
-        io_type = self._get_io_type(defs.IOType.NULL, defs.IOType.NULL,
-                                    io3_type, io4_type)
-        self._set_mode(defs.Mode.SERIAL.value, divisor + [io_type])
+        io_type = self._get_io_type(None, None, io3_type, io4_type)
+        self._set_mode(defs.Mode.SERIAL.value, divisor + [io_type & 0xF0])
         self.current_io_type = io_type
 
     def read_module_id(self):
@@ -218,13 +216,13 @@ class UsbIss(object):
     def _get_io_type(self, io1_type, io2_type, io3_type, io4_type):
         new_io_type = self.current_io_type
 
-        if io1_type != defs.IOType.NULL:
+        if io1_type is not None:
             new_io_type = (new_io_type & 0xFC) | (io1_type.value << 0)
-        if io2_type != defs.IOType.NULL:
+        if io2_type is not None:
             new_io_type = (new_io_type & 0xF3) | (io2_type.value << 2)
-        if io3_type != defs.IOType.NULL:
+        if io3_type is not None:
             new_io_type = (new_io_type & 0xCF) | (io3_type.value << 4)
-        if io4_type != defs.IOType.NULL:
+        if io4_type is not None:
             new_io_type = (new_io_type & 0x3F) | (io4_type.value << 6)
 
         return new_io_type

--- a/tests/test_usb_iss.py
+++ b/tests/test_usb_iss.py
@@ -48,7 +48,7 @@ class TestUSbIss(unittest.TestCase):
                 io2_type=defs.IOType.OUTPUT_HIGH)
 
             assert_that(self.driver.write_cmd,
-                        called_with(0x5A, [0x02, i2c_mode, 0x04]))
+                        called_with(0x5A, [0x02, i2c_mode, 0xA4]))
 
     def test_setup_i2c_default_values(self):
         self.usb_iss.setup_i2c()
@@ -57,6 +57,8 @@ class TestUSbIss(unittest.TestCase):
                     called_once_with(0x5A, [
                         0x02,
                         defs.Mode.I2C_H_400KHZ.value,
+                        defs.IOType.DIGITAL_INPUT.value << 6 |
+                        defs.IOType.DIGITAL_INPUT.value << 4 |
                         defs.IOType.DIGITAL_INPUT.value << 2 |
                         defs.IOType.DIGITAL_INPUT.value]))
 
@@ -266,7 +268,7 @@ class TestUSbIss(unittest.TestCase):
                                       io4_type=defs.IOType.OUTPUT_HIGH)
 
             assert_that(self.driver.write_cmd,
-                        called_with(0x5A, [0x02, 0x01] + divisor + [0x40]))
+                        called_with(0x5A, [0x02, 0x01] + divisor + [0x4A]))
 
     def test_setup_serial_default_values(self):
         self.usb_iss.setup_serial()
@@ -275,7 +277,9 @@ class TestUSbIss(unittest.TestCase):
                     called_once_with(0x5A,
                                      [0x02, 0x01, 0x01, 0x37,
                                       defs.IOType.DIGITAL_INPUT.value << 6 |
-                                      defs.IOType.DIGITAL_INPUT.value << 4]))
+                                      defs.IOType.DIGITAL_INPUT.value << 4 |
+                                      defs.IOType.DIGITAL_INPUT.value << 2 |
+                                      defs.IOType.DIGITAL_INPUT.value]))
 
     def test_setup_serial_failure(self):
         self.driver.check_ack_error_code.side_effect = UsbIssError
@@ -321,3 +325,116 @@ class TestUSbIss(unittest.TestCase):
         assert_that(result, is_("00000001"))
         assert_that(self.driver.write_cmd, called_once_with(0x5A, [0x03]))
         assert_that(self.driver.read, called_once_with(8))
+
+    def test_setup_io_then_change_io_defaults(self):
+        self.usb_iss.setup_io(
+            io1_type=defs.IOType.OUTPUT_LOW,
+            io2_type=defs.IOType.OUTPUT_HIGH,
+            io3_type=defs.IOType.ANALOGUE_INPUT,
+            io4_type=defs.IOType.DIGITAL_INPUT)
+
+        assert_that(self.driver.write_cmd,
+                    called_with(0x5A, [0x02, 0x00, 0xB4]))
+
+        self.usb_iss.change_io()
+
+        assert_that(self.driver.write_cmd,
+                    called_with(0x5A, [
+                        0x02,
+                        0x10,
+                        defs.IOType.DIGITAL_INPUT.value << 6 |
+                        defs.IOType.ANALOGUE_INPUT.value << 4 |
+                        defs.IOType.OUTPUT_HIGH.value << 2 |
+                        defs.IOType.OUTPUT_LOW.value]))
+
+    def test_setup_io_then_change_io(self):
+        self.usb_iss.setup_io(
+            io1_type=defs.IOType.OUTPUT_LOW,
+            io2_type=defs.IOType.OUTPUT_HIGH,
+            io3_type=defs.IOType.ANALOGUE_INPUT,
+            io4_type=defs.IOType.DIGITAL_INPUT)
+
+        assert_that(self.driver.write_cmd,
+                    called_with(0x5A, [0x02, 0x00, 0xB4]))
+
+        self.usb_iss.change_io(
+            io1_type=defs.IOType.DIGITAL_INPUT,
+            io2_type=defs.IOType.ANALOGUE_INPUT,
+            io3_type=defs.IOType.OUTPUT_HIGH,
+            io4_type=defs.IOType.OUTPUT_LOW)
+
+        assert_that(self.driver.write_cmd,
+                    called_with(0x5A, [
+                        0x02,
+                        0x10,
+                        defs.IOType.OUTPUT_LOW.value << 6 |
+                        defs.IOType.OUTPUT_HIGH.value << 4 |
+                        defs.IOType.ANALOGUE_INPUT.value << 2 |
+                        defs.IOType.DIGITAL_INPUT.value]))
+
+    def test_setup_io_then_change_io_partial(self):
+        self.usb_iss.setup_io(
+            io1_type=defs.IOType.OUTPUT_LOW,
+            io2_type=defs.IOType.OUTPUT_HIGH,
+            io3_type=defs.IOType.ANALOGUE_INPUT,
+            io4_type=defs.IOType.DIGITAL_INPUT)
+
+        assert_that(self.driver.write_cmd,
+                    called_with(0x5A, [0x02, 0x00, 0xB4]))
+
+        self.usb_iss.change_io(
+            io1_type=defs.IOType.DIGITAL_INPUT,
+            io3_type=defs.IOType.OUTPUT_HIGH)
+
+        assert_that(self.driver.write_cmd,
+                    called_with(0x5A, [
+                        0x02,
+                        0x10,
+                        defs.IOType.DIGITAL_INPUT.value << 6 |
+                        defs.IOType.OUTPUT_HIGH.value << 4 |
+                        defs.IOType.OUTPUT_HIGH.value << 2 |
+                        defs.IOType.DIGITAL_INPUT.value]))
+
+    def test_setup_io_then_setup_i2c_override(self):
+        self.usb_iss.setup_io(
+            io1_type=defs.IOType.OUTPUT_LOW,
+            io2_type=defs.IOType.OUTPUT_HIGH,
+            io3_type=defs.IOType.ANALOGUE_INPUT,
+            io4_type=defs.IOType.DIGITAL_INPUT)
+
+        assert_that(self.driver.write_cmd,
+                    called_with(0x5A, [0x02, 0x00, 0xB4]))
+
+        self.usb_iss.setup_i2c(
+            io1_type=defs.IOType.DIGITAL_INPUT,
+            io2_type=defs.IOType.ANALOGUE_INPUT)
+
+        assert_that(self.driver.write_cmd,
+                    called_with(0x5A, [
+                        0x02,
+                        defs.Mode.I2C_H_400KHZ.value,
+                        defs.IOType.DIGITAL_INPUT.value << 6 |
+                        defs.IOType.ANALOGUE_INPUT.value << 4 |
+                        defs.IOType.ANALOGUE_INPUT.value << 2 |
+                        defs.IOType.DIGITAL_INPUT.value]))
+
+    def test_setup_io_then_setup_i2c_defaults(self):
+        self.usb_iss.setup_io(
+            io1_type=defs.IOType.OUTPUT_LOW,
+            io2_type=defs.IOType.OUTPUT_HIGH,
+            io3_type=defs.IOType.ANALOGUE_INPUT,
+            io4_type=defs.IOType.DIGITAL_INPUT)
+
+        assert_that(self.driver.write_cmd,
+                    called_with(0x5A, [0x02, 0x00, 0xB4]))
+
+        self.usb_iss.setup_i2c()
+
+        assert_that(self.driver.write_cmd,
+                    called_with(0x5A, [
+                        0x02,
+                        defs.Mode.I2C_H_400KHZ.value,
+                        defs.IOType.DIGITAL_INPUT.value << 6 |
+                        defs.IOType.ANALOGUE_INPUT.value << 4 |
+                        defs.IOType.OUTPUT_HIGH.value << 2 |
+                        defs.IOType.OUTPUT_LOW.value]))

--- a/tests/test_usb_iss.py
+++ b/tests/test_usb_iss.py
@@ -48,7 +48,7 @@ class TestUSbIss(unittest.TestCase):
                 io2_type=defs.IOType.OUTPUT_HIGH)
 
             assert_that(self.driver.write_cmd,
-                        called_with(0x5A, [0x02, i2c_mode, 0xA4]))
+                        called_with(0x5A, [0x02, i2c_mode, 0x04]))
 
     def test_setup_i2c_default_values(self):
         self.usb_iss.setup_i2c()
@@ -57,8 +57,6 @@ class TestUSbIss(unittest.TestCase):
                     called_once_with(0x5A, [
                         0x02,
                         defs.Mode.I2C_H_400KHZ.value,
-                        defs.IOType.DIGITAL_INPUT.value << 6 |
-                        defs.IOType.DIGITAL_INPUT.value << 4 |
                         defs.IOType.DIGITAL_INPUT.value << 2 |
                         defs.IOType.DIGITAL_INPUT.value]))
 
@@ -268,7 +266,7 @@ class TestUSbIss(unittest.TestCase):
                                       io4_type=defs.IOType.OUTPUT_HIGH)
 
             assert_that(self.driver.write_cmd,
-                        called_with(0x5A, [0x02, 0x01] + divisor + [0x4A]))
+                        called_with(0x5A, [0x02, 0x01] + divisor + [0x40]))
 
     def test_setup_serial_default_values(self):
         self.usb_iss.setup_serial()
@@ -277,9 +275,7 @@ class TestUSbIss(unittest.TestCase):
                     called_once_with(0x5A,
                                      [0x02, 0x01, 0x01, 0x37,
                                       defs.IOType.DIGITAL_INPUT.value << 6 |
-                                      defs.IOType.DIGITAL_INPUT.value << 4 |
-                                      defs.IOType.DIGITAL_INPUT.value << 2 |
-                                      defs.IOType.DIGITAL_INPUT.value]))
+                                      defs.IOType.DIGITAL_INPUT.value << 4]))
 
     def test_setup_serial_failure(self):
         self.driver.check_ack_error_code.side_effect = UsbIssError
@@ -403,7 +399,13 @@ class TestUSbIss(unittest.TestCase):
             io4_type=defs.IOType.DIGITAL_INPUT)
 
         assert_that(self.driver.write_cmd,
-                    called_with(0x5A, [0x02, 0x00, 0xB4]))
+                    called_with(0x5A, [
+                        0x02,
+                        0x00,
+                        defs.IOType.DIGITAL_INPUT.value << 6 |
+                        defs.IOType.ANALOGUE_INPUT.value << 4 |
+                        defs.IOType.OUTPUT_HIGH.value << 2 |
+                        defs.IOType.OUTPUT_LOW.value]))
 
         self.usb_iss.setup_i2c(
             io1_type=defs.IOType.DIGITAL_INPUT,
@@ -413,8 +415,6 @@ class TestUSbIss(unittest.TestCase):
                     called_with(0x5A, [
                         0x02,
                         defs.Mode.I2C_H_400KHZ.value,
-                        defs.IOType.DIGITAL_INPUT.value << 6 |
-                        defs.IOType.ANALOGUE_INPUT.value << 4 |
                         defs.IOType.ANALOGUE_INPUT.value << 2 |
                         defs.IOType.DIGITAL_INPUT.value]))
 
@@ -426,7 +426,13 @@ class TestUSbIss(unittest.TestCase):
             io4_type=defs.IOType.DIGITAL_INPUT)
 
         assert_that(self.driver.write_cmd,
-                    called_with(0x5A, [0x02, 0x00, 0xB4]))
+                    called_with(0x5A, [
+                        0x02,
+                        0x00,
+                        defs.IOType.DIGITAL_INPUT.value << 6 |
+                        defs.IOType.ANALOGUE_INPUT.value << 4 |
+                        defs.IOType.OUTPUT_HIGH.value << 2 |
+                        defs.IOType.OUTPUT_LOW.value]))
 
         self.usb_iss.setup_i2c()
 
@@ -434,7 +440,28 @@ class TestUSbIss(unittest.TestCase):
                     called_with(0x5A, [
                         0x02,
                         defs.Mode.I2C_H_400KHZ.value,
-                        defs.IOType.DIGITAL_INPUT.value << 6 |
-                        defs.IOType.ANALOGUE_INPUT.value << 4 |
                         defs.IOType.OUTPUT_HIGH.value << 2 |
+                        defs.IOType.OUTPUT_LOW.value]))
+
+    def test_setup_i2c_defaults_then_change_io_partial(self):
+        self.usb_iss.setup_i2c()
+
+        assert_that(self.driver.write_cmd,
+                    called_with(0x5A, [
+                        0x02,
+                        defs.Mode.I2C_H_400KHZ.value,
+                        defs.IOType.DIGITAL_INPUT.value << 2 |
+                        defs.IOType.DIGITAL_INPUT.value]))
+
+        self.usb_iss.change_io(
+            io1_type=defs.IOType.OUTPUT_LOW,
+            io4_type=defs.IOType.OUTPUT_HIGH)
+
+        assert_that(self.driver.write_cmd,
+                    called_with(0x5A, [
+                        0x02,
+                        0x10,
+                        defs.IOType.OUTPUT_HIGH.value << 6 |
+                        defs.IOType.DIGITAL_INPUT.value << 4 |
+                        defs.IOType.DIGITAL_INPUT.value << 2 |
                         defs.IOType.OUTPUT_LOW.value]))


### PR DESCRIPTION
As per issue #96 I've made changes to allow UsbIss to remember the previous I/O state. This does break the API slightly however, so it would be a minor version bump as a minimum.

In the tests I've also noticed a mixture of literal expected values and calculated values. Should these be made consistent?