### PR TITLE
Use 7-bit I2C device addresses

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,9 +46,10 @@ Usage Example
     iss.setup_i2c()
 
     # Write and read back some data
+    # NOTE: I2C methods use 7-bit device addresses (0x00 - 0x7F)
 
-    iss.i2c.write(0xC4, 0, [0, 1, 2]);
-    data = iss.i2c.read(0xC4, 0, 3)
+    iss.i2c.write(0x62, 0, [0, 1, 2]);
+    data = iss.i2c.read(0x62, 0, 3)
 
     print(data)
     # [0, 1, 2]

--- a/src/usb_iss/i2c.py
+++ b/src/usb_iss/i2c.py
@@ -20,9 +20,10 @@ class I2C(object):
             iss.setup_i2c()
 
             # Write and read back some data
+            # NOTE: I2C methods use 7-bit device addresses (0x00 - 0x7F)
 
-            iss.i2c.write(0xC4, 0, [0, 1, 2]);
-            data = iss.i2c.read(0xC4, 0, 3)
+            iss.i2c.write(0x62, 0, [0, 1, 2]);
+            data = iss.i2c.read(0x62, 0, 3)
 
             print(data)
             # [0, 1, 2]
@@ -37,7 +38,7 @@ class I2C(object):
         majority of devices.
 
         Args:
-            address (int): I2C address of the device.
+            address (int): 7-bit I2C address of the device (0x00 - 0x7F).
             register (int): Internal register address to write
                 (0x00 - 0xFF).
             data (list of int): List of bytes to write to the device.
@@ -51,7 +52,7 @@ class I2C(object):
         of devices.
 
         Args:
-            address (int): I2C address of the device.
+            address (int): 7-bit I2C address of the device (0x00 - 0x7F).
             register (int): Internal register address to read (0x00 - 0xFF).
             byte_count (int): Number of bytes to read.
         Returns:
@@ -64,12 +65,12 @@ class I2C(object):
         Write a single byte to an I2C device.
 
         Args:
-            address (int): I2C address of the device.
+            address (int): 7-bit I2C address of the device (0x00 - 0x7F).
             data_byte (int): Data byte to write to the device.
         """
-        address = address & ~I2C_RD
+        address_8bit = address << 1
         self._drv.write_cmd(defs.Command.I2C_SGL.value,
-                            [address, data_byte])
+                            [address_8bit, data_byte])
         self._drv.check_i2c_ack()
 
     def read_single(self, address):
@@ -77,12 +78,12 @@ class I2C(object):
         Read a single byte from an I2C device.
 
         Args:
-            address (int): I2C address of the device.
+            address (int): 7-bit I2C address of the device (0x00 - 0x7F).
         Returns:
             int: Data byte read from the device.
         """
-        address = address | I2C_RD
-        self._drv.write_cmd(defs.Command.I2C_SGL.value, [address])
+        address_8bit = (address << 1) | I2C_RD
+        self._drv.write_cmd(defs.Command.I2C_SGL.value, [address_8bit])
         return self._drv.read(1)[0]
 
     def write_ad0(self, address, data):
@@ -91,12 +92,12 @@ class I2C(object):
         or where the internal register address does not require resetting.
 
         Args:
-            address (int): I2C address of the device.
+            address (int): 7-bit I2C address of the device (0x00 - 0x7F).
             data (list of int): List of bytes to write to the device.
         """
-        address = address & ~I2C_RD
+        address_8bit = address << 1
         self._drv.write_cmd(defs.Command.I2C_AD0.value,
-                            [address, len(data)] + data)
+                            [address_8bit, len(data)] + data)
         self._drv.check_i2c_ack()
 
     def read_ad0(self, address, byte_count):
@@ -105,14 +106,14 @@ class I2C(object):
         or where the internal register address does not require resetting.
 
         Args:
-            address (int): I2C address of the devie.
+            address (int): 7-bit I2C address of the devie.
             byte_count (int): Number of bytes to read.
         Returns:
             list of int: List of bytes read from the device.
         """
-        address = address | I2C_RD
+        address_8bit = (address << 1) | I2C_RD
         self._drv.write_cmd(defs.Command.I2C_AD0.value,
-                            [address, byte_count])
+                            [address_8bit, byte_count])
         return self._drv.read(byte_count)
 
     def write_ad1(self, address, register, data):
@@ -121,7 +122,7 @@ class I2C(object):
         address.
 
         Args:
-            address (int): I2C address of the device.
+            address (int): 7-bit I2C address of the device (0x00 - 0x7F).
             register (int): Internal register address to write (0x00 - 0xFF).
             data (list of int): List of bytes to write to the device.
         """
@@ -130,9 +131,9 @@ class I2C(object):
                 "Attempted to write %d bytes, maximum is %d" %
                 (len(data), defs.I2C_AD1_MAX_WRITE_BYTE_COUNT))
 
-        address = address & ~I2C_RD
+        address_8bit = address << 1
         self._drv.write_cmd(defs.Command.I2C_AD1.value,
-                            [address, register, len(data)] + data)
+                            [address_8bit, register, len(data)] + data)
         self._drv.check_i2c_ack()
 
     def read_ad1(self, address, register, byte_count):
@@ -141,7 +142,7 @@ class I2C(object):
         address.
 
         Args:
-            address (int): I2C address of the device.
+            address (int): 7-bit I2C address of the device (0x00 - 0x7F).
             register (int): Internal register address to read (0x00 - 0xFF).
             byte_count (int): Number of bytes to read.
         Returns:
@@ -152,9 +153,9 @@ class I2C(object):
                 "Attempted to read %d bytes, maximum is %d" %
                 (byte_count, defs.I2C_AD1_MAX_READ_BYTE_COUNT))
 
-        address = address | I2C_RD
+        address_8bit = (address << 1) | I2C_RD
         self._drv.write_cmd(defs.Command.I2C_AD1.value,
-                            [address, register, byte_count])
+                            [address_8bit, register, byte_count])
         return self._drv.read(byte_count)
 
     def write_ad2(self, address, register, data):
@@ -163,7 +164,7 @@ class I2C(object):
         address.
 
         Args:
-            address (int): I2C address of the device.
+            address (int): 7-bit I2C address of the device (0x00 - 0x7F).
             register (int): Internal register address to write
                 (0x0000 - 0xFFFF).
             data (list of int): List of bytes to write to the device.
@@ -173,11 +174,12 @@ class I2C(object):
                 "Attempted to write %d bytes, maximum is %d" %
                 (len(data), defs.I2C_AD2_MAX_WRITE_BYTE_COUNT))
 
-        address = address & ~I2C_RD
+        address_8bit = address << 1
         reg_high = register >> 8
         reg_low = register & 0xFF
-        self._drv.write_cmd(defs.Command.I2C_AD2.value,
-                            [address, reg_high, reg_low, len(data)] + data)
+        self._drv.write_cmd(
+            defs.Command.I2C_AD2.value,
+            [address_8bit, reg_high, reg_low, len(data)] + data)
         self._drv.check_i2c_ack()
 
     def read_ad2(self, address, register, byte_count):
@@ -186,7 +188,7 @@ class I2C(object):
         address.
 
         Args:
-            address (int): I2C address of the device.
+            address (int): 7-bit I2C address of the device (0x00 - 0x7F).
             register (int): Internal register address to read
                 (0x0000 - 0xFFFF).
             byte_count (int): Number of bytes to read.
@@ -198,11 +200,11 @@ class I2C(object):
                 "Attempted to read %d bytes, maximum is %d" %
                 (byte_count, defs.I2C_AD2_MAX_READ_BYTE_COUNT))
 
-        address = address | I2C_RD
+        address_8bit = (address << 1) | I2C_RD
         reg_high = register >> 8
         reg_low = register & 0xFF
         self._drv.write_cmd(defs.Command.I2C_AD2.value,
-                            [address, reg_high, reg_low, byte_count])
+                            [address_8bit, reg_high, reg_low, byte_count])
         return self._drv.read(byte_count)
 
     def direct(self, data):
@@ -248,10 +250,11 @@ class I2C(object):
         Check whether a device responds at the specified I2C addresss.
 
         Args:
-            address (int): I2C address of the device.
+            address (int): 7-bit I2C address of the device (0x00 - 0x7F).
 
         Returns:
             bool: True if the device responds with an ACK.
         """
-        self._drv.write_cmd(defs.Command.I2C_TEST.value, [address])
+        address_8bit = address << 1
+        self._drv.write_cmd(defs.Command.I2C_TEST.value, [address_8bit])
         return self._drv.read(1) != [defs.I2CTestResponse.NO_DEVICE.value]

--- a/src/usb_iss/usb_iss.py
+++ b/src/usb_iss/usb_iss.py
@@ -23,9 +23,10 @@ class UsbIss(object):
             iss.setup_i2c()
 
             # Write and read back some data
+            # NOTE: I2C methods use 7-bit device addresses (0x00 - 0x7F)
 
-            iss.i2c.write(0xC4, 0, [0, 1, 2]);
-            data = iss.i2c.read(0xC4, 0, 3)
+            iss.i2c.write(0x62, 0, [0, 1, 2]);
+            data = iss.i2c.read(0x62, 0, 3)
 
             print(data)
             # [0, 1, 2]

--- a/tests/test_i2c.py
+++ b/tests/test_i2c.py
@@ -18,7 +18,7 @@ class TestI2C(unittest.TestCase):
         self.i2c = I2C(self.driver)
 
     def test_write(self):
-        self.i2c.write(0xE0, 0x00, [0x51])
+        self.i2c.write(0x70, 0x00, [0x51])
 
         assert_that(self.driver.write_cmd,
                     called_once_with(0x55, [0xE0, 0x00, 0x01, 0x51]))
@@ -27,13 +27,13 @@ class TestI2C(unittest.TestCase):
         self.driver.check_i2c_ack.side_effect = UsbIssError
 
         assert_that(
-            calling(self.i2c.write).with_args(0xE0, 0x00, [0x51]),
+            calling(self.i2c.write).with_args(0x70, 0x00, [0x51]),
             raises(UsbIssError))
 
     def test_write_large_data(self):
         expected_data = list(range(60))
 
-        self.i2c.write(0xE0, 0x00, expected_data)
+        self.i2c.write(0x70, 0x00, expected_data)
 
         assert_that(self.driver.write_cmd,
                     called_once_with(0x55, [0xE0, 0x00, 60] + expected_data))
@@ -42,13 +42,13 @@ class TestI2C(unittest.TestCase):
         expected_data = list(range(61))
 
         assert_that(
-            calling(self.i2c.write).with_args(0xE0, 0x00, expected_data),
+            calling(self.i2c.write).with_args(0x70, 0x00, expected_data),
             raises(UsbIssError, "Attempted to write 61 bytes, maximum is 60"))
 
     def test_read(self):
         self.driver.read.return_value = [0x11, 0x22]
 
-        data = self.i2c.read(0xC1, 0x02, 2)
+        data = self.i2c.read(0x60, 0x02, 2)
 
         assert_that(self.driver.write_cmd,
                     called_once_with(0x55, [0xC1, 0x02, 2]))
@@ -59,14 +59,14 @@ class TestI2C(unittest.TestCase):
         self.driver.read.side_effect = UsbIssError
 
         assert_that(
-            calling(self.i2c.read).with_args(0xC1, 0x02, 2),
+            calling(self.i2c.read).with_args(0x60, 0x02, 2),
             raises(UsbIssError))
 
     def test_read_large_data(self):
         expected_data = list(range(60))
         self.driver.read.return_value = expected_data
 
-        data = self.i2c.read(0xC1, 0x02, 60)
+        data = self.i2c.read(0x60, 0x02, 60)
 
         assert_that(self.driver.write_cmd,
                     called_once_with(0x55, [0xC1, 0x02, 60]))
@@ -75,11 +75,11 @@ class TestI2C(unittest.TestCase):
 
     def test_read_overflow_failure(self):
         assert_that(
-            calling(self.i2c.read).with_args(0xC1, 0x02, 61),
+            calling(self.i2c.read).with_args(0x60, 0x02, 61),
             raises(UsbIssError, "Attempted to read 61 bytes, maximum is 60"))
 
     def test_write_single(self):
-        self.i2c.write_single(0x40, 0x00)
+        self.i2c.write_single(0x20, 0x00)
 
         assert_that(self.driver.write_cmd,
                     called_once_with(0x53, [0x40, 0x00]))
@@ -88,13 +88,13 @@ class TestI2C(unittest.TestCase):
         self.driver.check_i2c_ack.side_effect = UsbIssError
 
         assert_that(
-            calling(self.i2c.write_single).with_args(0x40, 0x00),
+            calling(self.i2c.write_single).with_args(0x20, 0x00),
             raises(UsbIssError))
 
     def test_read_single(self):
         self.driver.read.return_value = [0x42]
 
-        data = self.i2c.read_single(0x41)
+        data = self.i2c.read_single(0x20)
 
         assert_that(self.driver.write_cmd, called_once_with(0x53, [0x41]))
         assert_that(self.driver.read, called_once_with(1))
@@ -104,11 +104,11 @@ class TestI2C(unittest.TestCase):
         self.driver.read.side_effect = UsbIssError
 
         assert_that(
-            calling(self.i2c.read_single).with_args(0x41),
+            calling(self.i2c.read_single).with_args(0x20),
             raises(UsbIssError))
 
     def test_write_ad0(self):
-        self.i2c.write_ad0(0x30, [0x12, 0x34, 0x56, 0x78])
+        self.i2c.write_ad0(0x18, [0x12, 0x34, 0x56, 0x78])
 
         assert_that(self.driver.write_cmd,
                     called_once_with(0x54, [
@@ -119,13 +119,13 @@ class TestI2C(unittest.TestCase):
 
         assert_that(
             calling(self.i2c.write_ad0).
-            with_args(0x30, [0x12, 0x34, 0x56, 0x78]),
+            with_args(0x18, [0x12, 0x34, 0x56, 0x78]),
             raises(UsbIssError))
 
     def test_read_ad0(self):
         self.driver.read.return_value = [0x11, 0x22]
 
-        data = self.i2c.read_ad0(0xF1, 2)
+        data = self.i2c.read_ad0(0x78, 2)
 
         assert_that(self.driver.write_cmd, called_once_with(0x54, [0xF1, 2]))
         assert_that(self.driver.read, called_once_with(2))
@@ -135,11 +135,11 @@ class TestI2C(unittest.TestCase):
         self.driver.read.side_effect = UsbIssError
 
         assert_that(
-            calling(self.i2c.read_ad0).with_args(0xF1, 2),
+            calling(self.i2c.read_ad0).with_args(0x78, 2),
             raises(UsbIssError))
 
     def test_write_ad1(self):
-        self.i2c.write_ad1(0xE0, 0x00, [0x51])
+        self.i2c.write_ad1(0x70, 0x00, [0x51])
 
         assert_that(self.driver.write_cmd,
                     called_once_with(0x55, [0xE0, 0x00, 0x01, 0x51]))
@@ -148,13 +148,13 @@ class TestI2C(unittest.TestCase):
         self.driver.check_i2c_ack.side_effect = UsbIssError
 
         assert_that(
-            calling(self.i2c.write_ad1).with_args(0xE0, 0x00, [0x51]),
+            calling(self.i2c.write_ad1).with_args(0x70, 0x00, [0x51]),
             raises(UsbIssError))
 
     def test_write_ad1_large_data(self):
         expected_data = list(range(60))
 
-        self.i2c.write_ad1(0xE0, 0x00, expected_data)
+        self.i2c.write_ad1(0x70, 0x00, expected_data)
 
         assert_that(self.driver.write_cmd,
                     called_once_with(0x55, [0xE0, 0x00, 60] + expected_data))
@@ -163,13 +163,13 @@ class TestI2C(unittest.TestCase):
         expected_data = list(range(61))
 
         assert_that(
-            calling(self.i2c.write_ad1).with_args(0xE0, 0x00, expected_data),
+            calling(self.i2c.write_ad1).with_args(0x70, 0x00, expected_data),
             raises(UsbIssError, "Attempted to write 61 bytes, maximum is 60"))
 
     def test_read_ad1(self):
         self.driver.read.return_value = [0x11, 0x22]
 
-        data = self.i2c.read_ad1(0xC1, 0x02, 2)
+        data = self.i2c.read_ad1(0x60, 0x02, 2)
 
         assert_that(self.driver.write_cmd,
                     called_once_with(0x55, [0xC1, 0x02, 2]))
@@ -180,14 +180,14 @@ class TestI2C(unittest.TestCase):
         self.driver.read.side_effect = UsbIssError
 
         assert_that(
-            calling(self.i2c.read_ad1).with_args(0xC1, 0x02, 2),
+            calling(self.i2c.read_ad1).with_args(0x60, 0x02, 2),
             raises(UsbIssError))
 
     def test_read_ad1_large_data(self):
         expected_data = list(range(60))
         self.driver.read.return_value = expected_data
 
-        data = self.i2c.read_ad1(0xC1, 0x02, 60)
+        data = self.i2c.read_ad1(0x60, 0x02, 60)
 
         assert_that(self.driver.write_cmd,
                     called_once_with(0x55, [0xC1, 0x02, 60]))
@@ -196,11 +196,11 @@ class TestI2C(unittest.TestCase):
 
     def test_read_ad1_overflow_failure(self):
         assert_that(
-            calling(self.i2c.read_ad1).with_args(0xC1, 0x02, 61),
+            calling(self.i2c.read_ad1).with_args(0x60, 0x02, 61),
             raises(UsbIssError, "Attempted to read 61 bytes, maximum is 60"))
 
     def test_write_ad2(self):
-        self.i2c.write_ad2(0xA0, 0x1234, [0x51])
+        self.i2c.write_ad2(0x50, 0x1234, [0x51])
 
         assert_that(self.driver.write_cmd,
                     called_once_with(0x56, [0xA0, 0x12, 0x34, 1, 0x51]))
@@ -209,13 +209,13 @@ class TestI2C(unittest.TestCase):
         self.driver.check_i2c_ack.side_effect = UsbIssError
 
         assert_that(
-            calling(self.i2c.write_ad2).with_args(0xA0, 0x1234, [0x51]),
+            calling(self.i2c.write_ad2).with_args(0x50, 0x1234, [0x51]),
             raises(UsbIssError))
 
     def test_write_ad2_large_data(self):
         expected_data = list(range(59))
 
-        self.i2c.write_ad2(0xA0, 0x1234, expected_data)
+        self.i2c.write_ad2(0x50, 0x1234, expected_data)
 
         assert_that(self.driver.write_cmd,
                     called_once_with(0x56, [
@@ -225,13 +225,13 @@ class TestI2C(unittest.TestCase):
         expected_data = list(range(60))
 
         assert_that(
-            calling(self.i2c.write_ad2).with_args(0xA0, 0x1234, expected_data),
+            calling(self.i2c.write_ad2).with_args(0x50, 0x1234, expected_data),
             raises(UsbIssError, "Attempted to write 60 bytes, maximum is 59"))
 
     def test_read_ad2(self):
         self.driver.read.return_value = [0x11, 0x22]
 
-        data = self.i2c.read_ad2(0xA1, 0x4321, 2)
+        data = self.i2c.read_ad2(0x50, 0x4321, 2)
 
         assert_that(self.driver.write_cmd,
                     called_once_with(0x56, [0xA1, 0x43, 0x21, 2]))
@@ -242,14 +242,14 @@ class TestI2C(unittest.TestCase):
         self.driver.read.side_effect = UsbIssError
 
         assert_that(
-            calling(self.i2c.read_ad2).with_args(0xA1, 0x4321, 2),
+            calling(self.i2c.read_ad2).with_args(0x50, 0x4321, 2),
             raises(UsbIssError))
 
     def test_read_ad2_large_data(self):
         expected_data = list(range(64))
         self.driver.read.return_value = expected_data
 
-        data = self.i2c.read_ad2(0xA1, 0x4321, 64)
+        data = self.i2c.read_ad2(0x50, 0x4321, 64)
 
         assert_that(self.driver.write_cmd,
                     called_once_with(0x56, [0xA1, 0x43, 0x21, 64]))
@@ -258,7 +258,7 @@ class TestI2C(unittest.TestCase):
 
     def test_read_ad2_overflow_failure(self):
         assert_that(
-            calling(self.i2c.read_ad2).with_args(0xC1, 0x02, 65),
+            calling(self.i2c.read_ad2).with_args(0x50, 0x02, 65),
             raises(UsbIssError, "Attempted to read 65 bytes, maximum is 64"))
 
     def test_direct(self):
@@ -302,7 +302,7 @@ class TestI2C(unittest.TestCase):
 
     def test_test_with_device(self):
         self.driver.read.return_value = [0xFF]
-        device_present = self.i2c.test(0xA0)
+        device_present = self.i2c.test(0x50)
 
         assert_that(self.driver.write_cmd, called_once_with(0x58, [0xA0]))
         assert_that(self.driver.read, called_once_with(1))
@@ -311,7 +311,7 @@ class TestI2C(unittest.TestCase):
     def test_test_without_device(self):
         self.driver.read.return_value = [0x00]
 
-        device_present = self.i2c.test(0xA0)
+        device_present = self.i2c.test(0x50)
 
         assert_that(self.driver.write_cmd, called_once_with(0x58, [0xA0]))
         assert_that(self.driver.read, called_once_with(1))


### PR DESCRIPTION
7-bit addressing is more common.
Add explicit notes to documentation.
This is a breaking change.